### PR TITLE
Fix typo that made the gem fail immediately upon installing

### DIFF
--- a/lib/generators/hotwire_native/hotwire_native_generator.rb
+++ b/lib/generators/hotwire_native/hotwire_native_generator.rb
@@ -23,7 +23,7 @@ class HotwireNativeGenerator < Rails::Generators::Base
 
   def add_detect_device_to_application_controller
     inject_into_file "app/controllers/application_controller.rb", after: "class ApplicationController < ActionController::Base\n" do
-      "  include DetectDevice\n"
+      "  include DeviceFormat\n"
     end
   end
 


### PR DESCRIPTION
The gem generator adds `include DetectDevice` to the application controller.

However, there's no controller concern named `DetectDevice` defined anywhere in the gem – the only controller concern is `DeviceFormat` – I'm assuming it's a typo in the generator, so I fixed it.

This typo makes the gem unusable, because upon installing the whole Rails project fails with error: `NameError (uninitialized constant ApplicationController::DetectDevice)` in the `application_controller.rb`